### PR TITLE
Batch processing for QR code byte arrays, including scale doubling

### DIFF
--- a/QRmaker/QRmaker.py
+++ b/QRmaker/QRmaker.py
@@ -66,7 +66,7 @@ for qrNum in range(stickerNum):
             y=0
 
     # cleanup the directory by removing the png files
-    os.remove('QR-%s.png' % qrNum)
+    # os.remove('QR-%s.png' % qrNum)
 
 # save the pdf
 c.save()

--- a/QRmaker/README.md
+++ b/QRmaker/README.md
@@ -1,0 +1,15 @@
+# Pre-Processing QR codes
+
+QRmaker will batch-create QR codes in the desired quantities, and exports PDFs aligned for label printing.
+
+  python QRmaker.py
+
+## Pre-processing for printing use
+
+The thermal printer requires bytecode arrays for all bitmaps, with a Processing utility to handle the conversion from PNG. Accordingly:
+
+1. Comment out line 69 to store (not remove) the intermediate PNG files.
+2. `mv [destination] *.png` to corral them in a temporary folder
+3. On OS X, a suitable rescaling tool is `sips`. The original images are 58px square, so: `sips -Z 116 *.png` will rescale to double size. `-Z` preserves aspect ratio.
+4. Run the Processing sketch to batch-convert `.png` to Python-friendly `.h` byte arrays. Adjust line 13 to give the full path of your input file directory.
+5. `cat *.h > all.h` to concatenate the files. Note that this orders the files unix-style, not OS X-style (so it goes 0, 1, 10, 100, 101, 102, 103... 119, 12, ...). Which presumably isn't an issue.

--- a/QRmaker/processed/bitmapImageConvert/bitmapImageConvert.pde
+++ b/QRmaker/processed/bitmapImageConvert/bitmapImageConvert.pde
@@ -1,0 +1,91 @@
+// THIS IS NOT ARDUINO CODE!  Runs in Processing IDE (www.processing.org).
+// Convert image to C header file suitable for the Adafruit_Thermal library.
+
+import java.io.File;
+
+void setup() {
+  // Select and load image
+  // selectInput("Select image file to convert:", "processImage");
+}
+
+void draw() {
+  // Where are the target files?
+  File dir = new File("/Users/jonathan/Documents/Development/Heart-of-Maker-Faire/QRmaker/processed/bitmapImageConvert");
+  File[] files = dir.listFiles();
+
+  String      filename, basename;
+  PrintWriter output;
+  int         pixelNum, byteNum, bytesOnLine = 99,
+              x, y, b, rowBytes, totalBytes, lastBit, sum;
+
+  // Iterate over files in directory
+  for( int i=0; i < files.length; i++ ) {
+    String path = files[i].getAbsolutePath();
+    println("Got file: " + path);
+
+    //Check the file type and work with png files
+    if( path.toLowerCase().endsWith(".png")) {
+      PImage img = loadImage( path );
+      println("Got file " + path);
+
+      // We now have the image. Do something with it!
+      // Morph filename into output filename and base name for data
+      filename = path;
+      x = filename.lastIndexOf('.');
+      if(x > 0) filename = filename.substring(0, x);  // Strip current extension
+      x = filename.lastIndexOf('/');
+      if(x > 0) basename = filename.substring(x + 1); // Strip path
+      else      basename = filename;
+      filename += ".h"; // Append '.h' to output filename
+      println("Writing output to ", filename);
+
+      // Calculate output size
+      rowBytes   = (img.width + 7) / 8;
+      totalBytes = rowBytes * img.height;
+      // Convert image to B&W, make pixels readable
+      img.filter(THRESHOLD);
+      img.loadPixels();
+
+      // Open header file for output (NOTE: WILL CLOBBER EXISTING .H FILE, if any)
+      output = createWriter(filename);
+
+      // Write image dimensions and beginning of array
+      output.println("#ifndef _" + basename + "_h_");
+      output.println("#define _" + basename + "_h_");
+      output.println();
+      output.println("#define " + basename + "_width  " + img.width);
+      output.println("#define " + basename + "_height " + img.height);
+      output.println();
+      output.print("static const uint8_t PROGMEM " + basename + "_data[] = {");
+
+      // Generate body of array
+      for(pixelNum=byteNum=y=0; y<img.height; y++) { // Each row...
+        for(x=0; x<rowBytes; x++) { // Each 8-pixel block within row...
+          lastBit = (x < rowBytes - 1) ? 1 : (1 << (rowBytes * 8 - img.width));
+          sum     = 0; // Clear accumulated 8 bits
+          for(b=128; b>=lastBit; b >>= 1) { // Each pixel within block...
+            if((img.pixels[pixelNum++] & 1) == 0) sum |= b; // If black pixel, set bit
+          }
+          if(++bytesOnLine >= 10) { // Wrap nicely
+              output.print("\n ");
+              bytesOnLine = 0;
+          }
+          output.format(" 0x%02X", sum); // Write accumulated bits
+          if(++byteNum < totalBytes) output.print(',');
+        }
+      }
+
+      // End array, close file, exit program
+      output.println();
+      output.println("};");
+      output.println();
+      output.println("#endif // _" + basename + "_h_");
+      output.flush();
+      output.close();
+      println("Done!");
+
+    }
+
+  }
+  exit();
+}


### PR DESCRIPTION
See QRmaker/README.md for instructions. This isn’t completely
automated, but since it’s theoretically a ‘do once’ sort of job it’s
probably worth preserving flexibility.

Of note: now pixel-doubled, the ‘all.h’ file containing the byte arrays
is >5Mb. This shouldn’t be a problem for Pi/Python, but it’s way too
large for an Arduino… and it’s clearly a C-format header file. So
there’s probably a round of tweaking of the Processing code required
before final output.